### PR TITLE
Fix: navbar z-index issue to stay above page content

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -4,7 +4,7 @@ import { strings } from "../strings";
 
 export default function Navbar() {
   return (
-    <nav className={"bg-blue-950 text-white p-3 flex flex-row fixed w-full"}>
+    <nav className={"bg-blue-950 text-white p-3 flex flex-row fixed w-full z-50"}>
       <div
         className={
           "container mx-auto flex flex-row items-center justify-between"


### PR DESCRIPTION
This PR fixes the issue where the navbar was being overlapped by page content while scrolling.
Added a higher z-index to ensure the navbar stays above all other elements.