### PR TITLE
Fixed button alignment issue when username is too long.

### DIFF
--- a/src/components/IssueList.tsx
+++ b/src/components/IssueList.tsx
@@ -111,7 +111,7 @@ export default function IssueList(props: IssueListI) {
                               rel="noreferrer"
                               href={`https://github.com/${profile}`}
                             >
-                              {profile}
+                              {profile.slice(0, 14)}
                             </a>
                           </Popover>
 

--- a/src/components/IssueList.tsx
+++ b/src/components/IssueList.tsx
@@ -111,7 +111,7 @@ export default function IssueList(props: IssueListI) {
                               rel="noreferrer"
                               href={`https://github.com/${profile}`}
                             >
-                              {profile.slice(0, 14)}
+                              {profile.length > 15 ? profile.slice(0, 17)+"..." : profile}
                             </a>
                           </Popover>
 


### PR DESCRIPTION
### Sliced the username to ensure buttons remain aligned horizontally, preventing vertical misalignment.

--- 

### Before 

<img width="375" height="812" alt="Screenshot 2025-09-22 133422" src="https://github.com/user-attachments/assets/90563d16-f980-493a-b867-fd823dfa4737" />


### After

<img width="362" height="792" alt="image" src="https://github.com/user-attachments/assets/299f10f9-bf32-4428-bcc1-ace9a758412a" />

---

fixes #34 